### PR TITLE
fix: Add support for Esri 3.x and 4.x channel when handling response

### DIFF
--- a/src/activities/RunArcFMElectricTrace.ts
+++ b/src/activities/RunArcFMElectricTrace.ts
@@ -183,7 +183,7 @@ export class RunArcFMElectricTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.data?.results || [];
+        const results = (channel.response.payload as any)?.results || [];
 
         return {
             results,

--- a/src/activities/RunArcFMElectricTrace.ts
+++ b/src/activities/RunArcFMElectricTrace.ts
@@ -183,7 +183,10 @@ export class RunArcFMElectricTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.results || [];
+        const responseData =
+            channel.response.payload &&
+            (channel.getResponseData(channel.response.payload) as any);
+        const results = responseData?.results || [];
 
         return {
             results,

--- a/src/activities/RunArcFMGasTrace.ts
+++ b/src/activities/RunArcFMGasTrace.ts
@@ -180,7 +180,10 @@ export class RunArcFMGasTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.results || [];
+        const responseData =
+            channel.response.payload &&
+            (channel.getResponseData(channel.response.payload) as any);
+        const results = responseData?.results || [];
 
         return {
             results,

--- a/src/activities/RunArcFMGasTrace.ts
+++ b/src/activities/RunArcFMGasTrace.ts
@@ -180,7 +180,7 @@ export class RunArcFMGasTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.data?.results || [];
+        const results = (channel.response.payload as any)?.results || [];
 
         return {
             results,

--- a/src/activities/RunArcFMWaterTrace.ts
+++ b/src/activities/RunArcFMWaterTrace.ts
@@ -174,7 +174,10 @@ export class RunArcFMWaterTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.results || [];
+        const responseData =
+            channel.response.payload &&
+            (channel.getResponseData(channel.response.payload) as any);
+        const results = responseData?.results || [];
 
         return {
             results,

--- a/src/activities/RunArcFMWaterTrace.ts
+++ b/src/activities/RunArcFMWaterTrace.ts
@@ -174,7 +174,7 @@ export class RunArcFMWaterTrace implements IActivityHandler {
             channel.cancel();
         });
 
-        const results = (channel.response.payload as any)?.data?.results || [];
+        const results = (channel.response.payload as any)?.results || [];
 
         return {
             results,


### PR DESCRIPTION
(channel.response.payload as any)?.data from
results.